### PR TITLE
* Issue #364 Fixed Item Split and Animation Split Exports

### DIFF
--- a/sources/canvas/renderer.js
+++ b/sources/canvas/renderer.js
@@ -89,7 +89,6 @@ export async function renderCharacter(
     }
 
     // Build list of items to draw
-    const itemsToDraw = [];
     const customAnimationItems = []; // Track items with custom animations
 
     for (const [, selection] of Object.entries(selections)) {

--- a/sources/canvas/renderer.js
+++ b/sources/canvas/renderer.js
@@ -91,7 +91,6 @@ export async function renderCharacter(
     // Build list of items to draw
     const itemsToDraw = [];
     const customAnimationItems = []; // Track items with custom animations
-    const addedCustomAnimations = new Set(); // Track which custom animations we've added
 
     for (const [, selection] of Object.entries(selections)) {
       const { itemId, subId, variant } = selection;

--- a/sources/state/meta.js
+++ b/sources/state/meta.js
@@ -30,9 +30,6 @@ export function getSortedLayers(itemId, standardOnly = false) {
   }
 
   // Sort by animation first, then by zPos
-  layersList.sort((a, b) => {
-    return a.zPos - b.zPos;
-  });
   return layersList;
 }
 

--- a/sources/state/zip.js
+++ b/sources/state/zip.js
@@ -206,14 +206,17 @@ export const exportSplitItemSheets = async (deps = {}) => {
     // Render each item individually
     for (const [, selection] of Object.entries(state.selections)) {
       const { itemId, variant, name } = selection;
-      const layers = getSortedLayers(itemId, true);
+      let layers = getSortedLayers(itemId, true);
+      if (!layers || layers.length === 0) {
+        // If no layers found when skipping custom animations, grab ONLY custom animations
+        layers = getSortedLayers(itemId);
+      }
 
       // Get Multiple Recolors If Available
       const recolors = getMultiRecolors(itemId, state.selections);
 
       // Render each layer of the item separately
       for (const layer of layers) {
-        if (layer.custom_animation) continue;
         const fileName = getItemFileName(itemId, variant, name, layer.layerNum);
         try {
           // Render just this one item

--- a/tests/state/zip_spec.js
+++ b/tests/state/zip_spec.js
@@ -115,6 +115,19 @@ const ZIP_SPEC_ITEM_METADATA = {
       },
     },
   },
+  longsword: {
+    name: "Longsword",
+    type_name: "weapon",
+    required: ["male", "female", "teen", "muscular", "pregnant"],
+    animations: ["walk"],
+    layers: {
+      layer_1: {
+        custom_animation: "walk_128",
+        zPos: 140,
+        male: "weapon/sword/longsword_alt/walk/"
+      }
+    },
+  },
 };
 
 describe("state/zip.js", () => {
@@ -397,6 +410,63 @@ describe("state/zip.js", () => {
         );
       expect(issueAlert, "partial failure alert").to.exist;
       expect(String(issueAlert.args[0])).to.include(secondFileName);
+    });
+
+    it("verify custom only animations also export correctly", async () => {
+      state.selections = {
+        body: {
+          itemId: "body",
+          variant: "light",
+          name: "Body color (light)",
+        },
+        head: {
+          itemId: "heads_human_male",
+          variant: "light",
+          name: "Human male (light)",
+        },
+        weapon: {
+          itemId: "longsword",
+          variant: "longsword",
+          name: "Longsword (longsword)",
+        },
+      };
+
+      window.JSZip = function FakeJSZip() {
+        fakeZip = createFakeJSZip();
+        return fakeZip;
+      };
+
+      const renderStub = sandbox.stub().resolves(nonEmptyItemCanvas());
+
+      await exportSplitItemSheets({ renderSingleItem: renderStub });
+
+      const bodyLayers = getSortedLayers("body", true);
+      const headLayers = getSortedLayers("heads_human_male", true);
+      const weaponLayers = getSortedLayers("longsword", true);
+      const realWeaponLayers = getSortedLayers("longsword");
+      const firstFileName = getItemFileName(
+        "body",
+        "light",
+        "Body color (light)",
+        bodyLayers[0].layerNum,
+      );
+      const secondFileName = getItemFileName(
+        "heads_human_male",
+        "light",
+        "Human male (light)",
+        headLayers[0].layerNum,
+      );
+      const thirdFileName = getItemFileName(
+        "longsword",
+        "longsword",
+        "Longsword (longsword)",
+        realWeaponLayers[0].layerNum,
+      );
+
+      expect(fakeZip.files.get(`items/${firstFileName}.png`)).to.exist;
+      expect(fakeZip.files.get(`items/${secondFileName}.png`)).to.exist;
+      expect(weaponLayers.length).to.equal(0);
+      expect(fakeZip.files.get(`items/${thirdFileName}.png`)).to.exist;
     });
   });
 


### PR DESCRIPTION
resolves https://github.com/LiberatedPixelCup/Universal-LPC-Spritesheet-Character-Generator/issues/364


Not sure if there's anything else you might want to implement via tests. I didn't fix any tests, I just fixed the exports.


Split by Item With an Asset containing ONLY Custom Animations:
<img width="646" height="340" alt="image" src="https://github.com/user-attachments/assets/fb3019d2-af5f-4cba-a714-dfa7ab12b388" />

Split by Animations With an Asset containing ONLY Custom Animations:
<img width="653" height="263" alt="image" src="https://github.com/user-attachments/assets/482f129a-d0ce-4ed6-ab69-2dc44277ec23" />


Export By Animations With an Asset Containing a Custom Animation + Standard Animations:
<img width="634" height="213" alt="image" src="https://github.com/user-attachments/assets/4e5b816f-7bb4-40fa-911b-3e0660c7b70e" />


Split by Items was only causing problems if an asset contained only custom animations, but if it had both it worked.

I also tested "animation and frame" just to be safe. This was also pulling addedCustomAnimations, so it was probably also failing prior to this fix, but its fixed now.